### PR TITLE
Removed a few boost dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.0.2)
+include(CheckIncludeFileCXX)
 project(mosaic_gnss_driver)
 
 add_compile_options(-std=c++17)
@@ -131,6 +132,16 @@ add_library(${PROJECT_NAME} STATIC
 target_compile_definitions(${PROJECT_NAME} PRIVATE MOSAIC_GNSS_CORE_ONLY)
 #target_compile_definitions(${PROJECT_NAME} PRIVATE MOSAIC_SBF_PRINT_ID)
 
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.4)
+	message(FATAL_ERROR " You are on an extremely old version of G++. Please update your compiler to at least G++ 5.4, preferably latest")
+	elseif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
+	set(EXP_FS_INCLUDE 1)
+	endif()
+else()
+	message(FATAL_ERROR " Please use G++ compiler to compile the project")
+endif()
+
 # Driver
 add_executable(${PROJECT_NAME}_node src/main.cpp)
 target_compile_definitions(${PROJECT_NAME}_node PRIVATE MOSAIC_GNSS_FAKE_SLEEP_TIME=0.1)
@@ -139,8 +150,13 @@ target_link_libraries(${PROJECT_NAME}_node
         ${PROJECT_NAME}
         ${catkin_LIBRARIES}
         ${libpcap_LIBRARIES}
-        ${Boost_LIBRARIES}
-		-lstdc++fs)
+        ${Boost_LIBRARIES})
+
+if (EXP_FS_INCLUDE)
+	target_link_libraries(${PROJECT_NAME}_node -lstdc++fs)
+	message([STATUS] " Using <experimental/filesystem> library...")
+endif(EXP_FS_INCLUDE)
+
 
 #############
 ## Install ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,8 @@ target_link_libraries(${PROJECT_NAME}_node
         ${PROJECT_NAME}
         ${catkin_LIBRARIES}
         ${libpcap_LIBRARIES}
-        ${Boost_LIBRARIES})
+        ${Boost_LIBRARIES}
+		-lstdc++fs)
 
 #############
 ## Install ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,6 @@ add_library(${PROJECT_NAME} STATIC
 target_compile_definitions(${PROJECT_NAME} PRIVATE MOSAIC_GNSS_CORE_ONLY)
 #target_compile_definitions(${PROJECT_NAME} PRIVATE MOSAIC_SBF_PRINT_ID)
 
-# TODO Extend support for LLVM Clang compiler
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.4)
 	message(FATAL_ERROR " You are on an extremely old version of G++. Please update your compiler to at least G++ 5.4, preferably latest")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ add_library(${PROJECT_NAME} STATIC
 target_compile_definitions(${PROJECT_NAME} PRIVATE MOSAIC_GNSS_CORE_ONLY)
 #target_compile_definitions(${PROJECT_NAME} PRIVATE MOSAIC_SBF_PRINT_ID)
 
+# TODO Extend support for LLVM Clang compiler
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.4)
 	message(FATAL_ERROR " You are on an extremely old version of G++. Please update your compiler to at least G++ 5.4, preferably latest")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.0.2)
-include(CheckIncludeFileCXX)
 project(mosaic_gnss_driver)
 
 add_compile_options(-std=c++17)
@@ -132,16 +131,6 @@ add_library(${PROJECT_NAME} STATIC
 target_compile_definitions(${PROJECT_NAME} PRIVATE MOSAIC_GNSS_CORE_ONLY)
 #target_compile_definitions(${PROJECT_NAME} PRIVATE MOSAIC_SBF_PRINT_ID)
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-	if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.4)
-	message(FATAL_ERROR " You are on an extremely old version of G++. Please update your compiler to at least G++ 5.4, preferably latest")
-	elseif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
-	set(EXP_FS_INCLUDE 1)
-	endif()
-else()
-	message(FATAL_ERROR " Please use G++ compiler to compile the project")
-endif()
-
 # Driver
 add_executable(${PROJECT_NAME}_node src/main.cpp)
 target_compile_definitions(${PROJECT_NAME}_node PRIVATE MOSAIC_GNSS_FAKE_SLEEP_TIME=0.1)
@@ -150,13 +139,8 @@ target_link_libraries(${PROJECT_NAME}_node
         ${PROJECT_NAME}
         ${catkin_LIBRARIES}
         ${libpcap_LIBRARIES}
-        ${Boost_LIBRARIES})
-
-if (EXP_FS_INCLUDE)
-	target_link_libraries(${PROJECT_NAME}_node -lstdc++fs)
-	message([STATUS] " Using <experimental/filesystem> library...")
-endif(EXP_FS_INCLUDE)
-
+        ${Boost_LIBRARIES}
+		-lstdc++fs)
 
 #############
 ## Install ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,7 @@ target_link_libraries(${PROJECT_NAME}_node
         ${libpcap_LIBRARIES}
         ${Boost_LIBRARIES}
 		-lstdc++fs)
+# TODO Link stdc++fs only when using <experimental/filesystem>; use some sort of conditional check to do this
 
 #############
 ## Install ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,6 @@ target_link_libraries(${PROJECT_NAME}_node
         ${libpcap_LIBRARIES}
         ${Boost_LIBRARIES}
 		-lstdc++fs)
-# TODO Link stdc++fs only when using <experimental/filesystem>; use some sort of conditional check to do this
 
 #############
 ## Install ##

--- a/include/mosaic_gnss_driver/connections/tcp.h
+++ b/include/mosaic_gnss_driver/connections/tcp.h
@@ -1,7 +1,7 @@
 #ifndef MOSAIC_GNSS_DRIVER_TCP_H
 #define MOSAIC_GNSS_DRIVER_TCP_H
 
-#include <boost/array.hpp>
+#include <array>
 #include <boost/asio.hpp>
 #include <mosaic_gnss_driver/connections/connection.h>
 
@@ -25,7 +25,7 @@ namespace mosaic_gnss_driver::connections {
 
         boost::asio::io_service m_IoService;
         boost::asio::ip::tcp::socket m_TcpSocket;
-        boost::array<uint8_t, 10000> m_SocketBuffer;
+        std::array<uint8_t, 10000> m_SocketBuffer;
 
     protected:
         static const size_t DEFAULT_TCP_PORT = 3001;

--- a/include/mosaic_gnss_driver/connections/udp.h
+++ b/include/mosaic_gnss_driver/connections/udp.h
@@ -1,8 +1,9 @@
 #ifndef MOSAIC_GNSS_DRIVER_UDP_H
 #define MOSAIC_GNSS_DRIVER_UDP_H
 
-#include <boost/array.hpp>
+#include <array>
 #include <boost/asio.hpp>
+#include <memory>
 #include <mosaic_gnss_driver/connections/connection.h>
 
 namespace mosaic_gnss_driver::connections {
@@ -15,9 +16,9 @@ namespace mosaic_gnss_driver::connections {
         static constexpr const char* const type = "UDP";
 
         boost::asio::io_service m_IoService;
-        boost::shared_ptr<boost::asio::ip::udp::socket> m_UdpSocket;
-        boost::shared_ptr<boost::asio::ip::udp::endpoint> m_UdpEndpoint;
-        boost::array<uint8_t, 10000> m_SocketBuffer;
+        std::shared_ptr<boost::asio::ip::udp::socket> m_UdpSocket;
+        std::shared_ptr<boost::asio::ip::udp::endpoint> m_UdpEndpoint;
+        std::array<uint8_t, 10000> m_SocketBuffer;
 
         /**
          * (Re)configure the driver with a set of message options

--- a/include/mosaic_gnss_driver/parsers/sbf/sbf.h
+++ b/include/mosaic_gnss_driver/parsers/sbf/sbf.h
@@ -99,8 +99,6 @@ namespace sbf {
         /**
          * Performs CRC check according to the SBF specification
          *
-         * TODO: Implement
-         *
          * @param bytes : Start of bytes to be CRC checked
          * @param length  : Number of bytes to be CRC checked
          * @param crc : The correct CRC value

--- a/src/core/connections/udp.cpp
+++ b/src/core/connections/udp.cpp
@@ -41,7 +41,7 @@ bool UDP::connect(const std::string& endpoint, const Options& opts)
             boost::asio::ip::udp::resolver resolver(m_IoService);
             boost::asio::ip::udp::resolver::query query(ip, port);
             m_UdpEndpoint =
-                boost::make_shared<boost::asio::ip::udp::endpoint>(*resolver.resolve(query));
+                std::make_shared<boost::asio::ip::udp::endpoint>(*resolver.resolve(query));
 
             m_UdpSocket.reset(new boost::asio::ip::udp::socket(m_IoService));
             m_UdpSocket->open(boost::asio::ip::udp::v4());
@@ -55,9 +55,9 @@ bool UDP::connect(const std::string& endpoint, const Options& opts)
                 m_IoService,
                 boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), portNumber)));
 
-            boost::array<char, 1> recvBuffer;
+            std::array<char, 1> recvBuffer;
 
-            m_UdpEndpoint = boost::make_shared<boost::asio::ip::udp::endpoint>();
+            m_UdpEndpoint = std::make_shared<boost::asio::ip::udp::endpoint>();
             boost::system::error_code error;
 
             ROS_INFO("Listening to UDP port %s", port.c_str());

--- a/src/core/util/serial.cpp
+++ b/src/core/util/serial.cpp
@@ -1,5 +1,5 @@
-#include <boost/lexical_cast.hpp>
 #include <mosaic_utils/serial.h>
+#include <string.h>
 
 // Linux headers
 #include <errno.h>        // Error integer and strerror() function
@@ -46,8 +46,7 @@ namespace serial_util {
         int32_t baud = _parseBaudRate(config.m_BaudRate);
         if (baud == -1)
         {
-            m_ErrorMessage =
-                "Invalid baud rate: " + boost::lexical_cast<std::string>(config.m_BaudRate);
+            m_ErrorMessage = "Invalid baud rate: " + config.m_BaudRate;
 
             return false;
         }
@@ -55,8 +54,7 @@ namespace serial_util {
         // Validate stop bits
         if (config.m_StopBits != 1 && config.m_StopBits != 2)
         {
-            m_ErrorMessage =
-                "Invalid stop bits: " + boost::lexical_cast<std::string>(config.m_StopBits);
+            m_ErrorMessage = "Invalid stop bits: " + std::to_string(config.m_StopBits);
 
             return false;
         }
@@ -64,8 +62,7 @@ namespace serial_util {
         // Validate data bits
         if (config.m_DataBits != 7 && config.m_DataBits != 8)
         {
-            m_ErrorMessage =
-                "Invalid data bits: " + boost::lexical_cast<std::string>(config.m_DataBits);
+            m_ErrorMessage = "Invalid data bits: " + std::to_string(config.m_DataBits);
 
             return false;
         }
@@ -144,8 +141,7 @@ namespace serial_util {
 
         if (cfsetspeed(&term, config.m_BaudRate) < 0)
         {
-            m_ErrorMessage =
-                "Invalid baud rate: " + boost::lexical_cast<std::string>(config.m_BaudRate);
+            m_ErrorMessage = "Invalid baud rate: " + std::to_string(config.m_BaudRate);
             serialClose();
 
             return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <mosaic_gnss_driver/node.hpp>
 #include <ros/package.h>
 
@@ -22,10 +22,10 @@ void initDriver(std::string& device, const std::string& conn)
 {
     if (conn == "pcap")
     {
-        namespace fs = boost::filesystem;
+        namespace fs = std::filesystem;
         // safely join paths
-        fs::path dir(ros::package::getPath("mosaic_gnss_driver"));
-        fs::path file(device);
+        fs::path dir = ros::package::getPath("mosaic_gnss_driver");
+        fs::path file = device;
         fs::path full_path = dir / file;
         device = full_path.string();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,15 @@
-#include <filesystem>
 #include <mosaic_gnss_driver/node.hpp>
 #include <ros/package.h>
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#error Could not find system header "<filesystem>" or "<experimental/filesystem>"
+#endif
 
 template <typename c_Tp, typename p_Tp>
 void launchDriver(const std::string& device)
@@ -22,7 +31,6 @@ void initDriver(std::string& device, const std::string& conn)
 {
     if (conn == "pcap")
     {
-        namespace fs = std::filesystem;
         // safely join paths
         fs::path dir = ros::package::getPath("mosaic_gnss_driver");
         fs::path file = device;


### PR DESCRIPTION
I have tried to remove all the boost dependencies which I could without breaking the project. All dependencies on `boost::filesystem`, `boost::lexical_cast`, `boost::array` and `boost::shared_ptr` have been removed. Dependencies on `boost::system::error_code` could also be removed by using `std::error_code`, but that would result in a loss of compatibility with `boost::asio`. So we would have to remove both the dependencies together. Only remaining boost dependency is `boost/asio.hpp`.