### PR TITLE
Removal of `boost::asio` dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,10 @@ docs/latex
 
 .vscode
 .idea
+.cache
 
 stderr.txt
 stdout.txt
 
 cmake-build-*
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ set(DEPS
         sensor_msgs
         nmea_msgs)
 
-find_package(Boost REQUIRED COMPONENTS system)
 find_package(catkin REQUIRED COMPONENTS ${DEPS})
 
 find_library(libpcap_LIBRARIES pcap)
@@ -102,8 +101,7 @@ endif()
 catkin_package(
         INCLUDE_DIRS include
         LIBRARIES ${PROJECT_NAME}
-        CATKIN_DEPENDS ${DEPS}
-        DEPENDS Boost)
+        CATKIN_DEPENDS ${DEPS})
 
 ###########
 ## Build ##
@@ -111,8 +109,7 @@ catkin_package(
 
 include_directories(
         include
-        ${catkin_INCLUDE_DIRS}
-        ${Boost_INCLUDE_DIRS})
+        ${catkin_INCLUDE_DIRS})
 
 ## Core Library
 add_library(${PROJECT_NAME} STATIC
@@ -139,7 +136,6 @@ target_link_libraries(${PROJECT_NAME}_node
         ${PROJECT_NAME}
         ${catkin_LIBRARIES}
         ${libpcap_LIBRARIES}
-        ${Boost_LIBRARIES}
 		-lstdc++fs)
 
 #############
@@ -170,7 +166,7 @@ if(CATKIN_ENABLE_TESTING)
                 ${PROJECT_NAME}
                 ${catkin_LIBRARIES}
                 ${libpcap_LIBRARIES}
-                ${Boost_LIBRARIES})
+				-lstdc++fs)
     endmacro(package_add_test)
 
     package_add_test(connection_test test/test_connection.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ target_link_libraries(${PROJECT_NAME}_node
         ${PROJECT_NAME}
         ${catkin_LIBRARIES}
         ${libpcap_LIBRARIES}
-		-lstdc++fs)
+        -lstdc++fs)
 
 #############
 ## Install ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ if(CATKIN_ENABLE_TESTING)
                 ${PROJECT_NAME}
                 ${catkin_LIBRARIES}
                 ${libpcap_LIBRARIES}
-				-lstdc++fs)
+                -lstdc++fs)
     endmacro(package_add_test)
 
     package_add_test(connection_test test/test_connection.cpp)

--- a/include/mosaic_gnss_driver/connections/tcp.h
+++ b/include/mosaic_gnss_driver/connections/tcp.h
@@ -2,7 +2,7 @@
 #define MOSAIC_GNSS_DRIVER_TCP_H
 
 #include <array>
-#include <boost/asio.hpp>
+#include <asio.hpp>
 #include <mosaic_gnss_driver/connections/connection.h>
 
 namespace mosaic_gnss_driver::connections {
@@ -23,8 +23,8 @@ namespace mosaic_gnss_driver::connections {
          */
         bool _configure(const Options& opts);
 
-        boost::asio::io_service m_IoService;
-        boost::asio::ip::tcp::socket m_TcpSocket;
+        asio::io_service m_IoService;
+        asio::ip::tcp::socket m_TcpSocket;
         std::array<uint8_t, 10000> m_SocketBuffer;
 
     protected:

--- a/include/mosaic_gnss_driver/connections/udp.h
+++ b/include/mosaic_gnss_driver/connections/udp.h
@@ -2,7 +2,7 @@
 #define MOSAIC_GNSS_DRIVER_UDP_H
 
 #include <array>
-#include <boost/asio.hpp>
+#include <asio.hpp>
 #include <memory>
 #include <mosaic_gnss_driver/connections/connection.h>
 
@@ -15,9 +15,9 @@ namespace mosaic_gnss_driver::connections {
     private:
         static constexpr const char* const type = "UDP";
 
-        boost::asio::io_service m_IoService;
-        std::shared_ptr<boost::asio::ip::udp::socket> m_UdpSocket;
-        std::shared_ptr<boost::asio::ip::udp::endpoint> m_UdpEndpoint;
+        asio::io_service m_IoService;
+        std::shared_ptr<asio::ip::udp::socket> m_UdpSocket;
+        std::shared_ptr<asio::ip::udp::endpoint> m_UdpEndpoint;
         std::array<uint8_t, 10000> m_SocketBuffer;
 
         /**

--- a/package.xml
+++ b/package.xml
@@ -23,7 +23,6 @@
     <depend>std_msgs</depend>
     <depend>sensor_msgs</depend>
     <depend>nmea_msgs</depend>
-    <depend>boost</depend>
     <depend>libpcap</depend>
 
     <test_depend>rostest</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -24,7 +24,7 @@
     <depend>sensor_msgs</depend>
     <depend>nmea_msgs</depend>
     <depend>libpcap</depend>
-    <depend>libasio-dev</depend>
+    <depend>asio</depend>
 
     <test_depend>rostest</test_depend>
     <export>

--- a/package.xml
+++ b/package.xml
@@ -24,7 +24,7 @@
     <depend>sensor_msgs</depend>
     <depend>nmea_msgs</depend>
     <depend>libpcap</depend>
-    <depend>libasio</depend>
+    <depend>libasio-dev</depend>
 
     <test_depend>rostest</test_depend>
     <export>

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
     <depend>sensor_msgs</depend>
     <depend>nmea_msgs</depend>
     <depend>libpcap</depend>
+    <depend>libasio</depend>
 
     <test_depend>rostest</test_depend>
     <export>

--- a/src/core/connections/tcp.cpp
+++ b/src/core/connections/tcp.cpp
@@ -53,8 +53,7 @@ bool TCP::connect(const std::string& endpoint, const Options& opts)
             auto portNumber = static_cast<uint16_t>(strtoll(port.c_str(), nullptr, 10));
 
             asio::ip::tcp::acceptor acceptor(
-                m_IoService,
-                asio::ip::tcp::endpoint(asio::ip::tcp::v4(), portNumber));
+                m_IoService, asio::ip::tcp::endpoint(asio::ip::tcp::v4(), portNumber));
 
             ROS_INFO("Listening to TCP port %s", port.c_str());
 
@@ -99,7 +98,7 @@ ReadResult TCP::read()
 {
     try
     {
-		std::error_code error;
+        std::error_code error;
         // number of bytes read from the socket
         size_t length;
 

--- a/src/core/connections/tcp.cpp
+++ b/src/core/connections/tcp.cpp
@@ -1,5 +1,6 @@
 #include <mosaic_gnss_driver/connections/tcp.h>
 #include <ros/ros.h>
+#include <system_error>
 
 using namespace mosaic_gnss_driver::connections;
 
@@ -40,20 +41,20 @@ bool TCP::connect(const std::string& endpoint, const Options& opts)
     {
         if (!ip.empty())
         {
-            boost::asio::ip::tcp::resolver resolver(m_IoService);
-            boost::asio::ip::tcp::resolver::query query(ip, port);
-            boost::asio::ip::tcp::resolver::iterator iter = resolver.resolve(query);
+            asio::ip::tcp::resolver resolver(m_IoService);
+            asio::ip::tcp::resolver::query query(ip, port);
+            asio::ip::tcp::resolver::iterator iter = resolver.resolve(query);
 
-            boost::asio::connect(m_TcpSocket, iter);
+            asio::connect(m_TcpSocket, iter);
 
             ROS_INFO("Connecting via TCP to %s:%s", ip.c_str(), port.c_str());
         } else
         {
             auto portNumber = static_cast<uint16_t>(strtoll(port.c_str(), nullptr, 10));
 
-            boost::asio::ip::tcp::acceptor acceptor(
+            asio::ip::tcp::acceptor acceptor(
                 m_IoService,
-                boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), portNumber));
+                asio::ip::tcp::endpoint(asio::ip::tcp::v4(), portNumber));
 
             ROS_INFO("Listening to TCP port %s", port.c_str());
 
@@ -98,11 +99,11 @@ ReadResult TCP::read()
 {
     try
     {
-        boost::system::error_code error;
+		std::error_code error;
         // number of bytes read from the socket
         size_t length;
 
-        length = m_TcpSocket.read_some(boost::asio::buffer(m_SocketBuffer), error);
+        length = m_TcpSocket.read_some(asio::buffer(m_SocketBuffer), error);
 
         buffer.insert(buffer.end(), m_SocketBuffer.begin(), m_SocketBuffer.begin() + length);
 
@@ -125,13 +126,13 @@ bool TCP::write(const std::string& command)
 {
     std::vector<uint8_t> bytes(command.begin(), command.end());
 
-    boost::system::error_code error;
+    std::error_code error;
 
     try
     {
         size_t written; // to store number of bytes written
 
-        written = boost::asio::write(m_TcpSocket, boost::asio::buffer(bytes), error);
+        written = asio::write(m_TcpSocket, asio::buffer(bytes), error);
 
         if (error)
         {

--- a/src/core/connections/tcp.cpp
+++ b/src/core/connections/tcp.cpp
@@ -1,6 +1,5 @@
 #include <mosaic_gnss_driver/connections/tcp.h>
 #include <ros/ros.h>
-#include <system_error>
 
 using namespace mosaic_gnss_driver::connections;
 

--- a/src/core/connections/udp.cpp
+++ b/src/core/connections/udp.cpp
@@ -38,35 +38,35 @@ bool UDP::connect(const std::string& endpoint, const Options& opts)
         if (!ip.empty())
         {
 
-            boost::asio::ip::udp::resolver resolver(m_IoService);
-            boost::asio::ip::udp::resolver::query query(ip, port);
+            asio::ip::udp::resolver resolver(m_IoService);
+            asio::ip::udp::resolver::query query(ip, port);
             m_UdpEndpoint =
-                std::make_shared<boost::asio::ip::udp::endpoint>(*resolver.resolve(query));
+                std::make_shared<asio::ip::udp::endpoint>(*resolver.resolve(query));
 
-            m_UdpSocket.reset(new boost::asio::ip::udp::socket(m_IoService));
-            m_UdpSocket->open(boost::asio::ip::udp::v4());
+            m_UdpSocket.reset(new asio::ip::udp::socket(m_IoService));
+            m_UdpSocket->open(asio::ip::udp::v4());
 
             ROS_INFO("Connecting via UDP to %s:%s", ip.c_str(), port.c_str());
         } else
         {
             auto portNumber = static_cast<uint16_t>(strtoll(port.c_str(), nullptr, 10));
 
-            m_UdpSocket.reset(new boost::asio::ip::udp::socket(
+            m_UdpSocket.reset(new asio::ip::udp::socket(
                 m_IoService,
-                boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), portNumber)));
+                asio::ip::udp::endpoint(asio::ip::udp::v4(), portNumber)));
 
             std::array<char, 1> recvBuffer;
 
-            m_UdpEndpoint = std::make_shared<boost::asio::ip::udp::endpoint>();
-            boost::system::error_code error;
+            m_UdpEndpoint = std::make_shared<asio::ip::udp::endpoint>();
+            std::error_code error;
 
             ROS_INFO("Listening to UDP port %s", port.c_str());
 
-            m_UdpSocket->receive_from(boost::asio::buffer(recvBuffer), *m_UdpEndpoint, 0, error);
+            m_UdpSocket->receive_from(asio::buffer(recvBuffer), *m_UdpEndpoint, 0, error);
 
-            if (error && error != boost::asio::error::message_size)
+            if (error && error != asio::error::message_size)
             {
-                throw boost::system::system_error(error);
+                throw std::system_error(error);
             }
 
             ROS_INFO("Accepted UDP Connection from client: %s",
@@ -119,12 +119,12 @@ ReadResult UDP::read()
 {
     try
     {
-        boost::system::error_code error;
+        std::error_code error;
         // number of bytes read from the socket
         size_t length;
 
-        boost::asio::ip::udp::endpoint remoteEndpoint;
-        length = m_UdpSocket->receive_from(boost::asio::buffer(m_SocketBuffer), remoteEndpoint);
+        asio::ip::udp::endpoint remoteEndpoint;
+        length = m_UdpSocket->receive_from(asio::buffer(m_SocketBuffer), remoteEndpoint);
 
         buffer.insert(buffer.end(), m_SocketBuffer.begin(), m_SocketBuffer.begin() + length);
 
@@ -147,13 +147,13 @@ bool UDP::write(const std::string& command)
 {
     std::vector<uint8_t> bytes(command.begin(), command.end());
 
-    boost::system::error_code error;
+    std::error_code error;
 
     try
     {
         size_t written; // to store number of bytes written
 
-        written = m_UdpSocket->send_to(boost::asio::buffer(bytes), *m_UdpEndpoint, 0, error);
+        written = m_UdpSocket->send_to(asio::buffer(bytes), *m_UdpEndpoint, 0, error);
 
         if (error)
         {

--- a/src/core/connections/udp.cpp
+++ b/src/core/connections/udp.cpp
@@ -40,8 +40,7 @@ bool UDP::connect(const std::string& endpoint, const Options& opts)
 
             asio::ip::udp::resolver resolver(m_IoService);
             asio::ip::udp::resolver::query query(ip, port);
-            m_UdpEndpoint =
-                std::make_shared<asio::ip::udp::endpoint>(*resolver.resolve(query));
+            m_UdpEndpoint = std::make_shared<asio::ip::udp::endpoint>(*resolver.resolve(query));
 
             m_UdpSocket.reset(new asio::ip::udp::socket(m_IoService));
             m_UdpSocket->open(asio::ip::udp::v4());
@@ -52,8 +51,7 @@ bool UDP::connect(const std::string& endpoint, const Options& opts)
             auto portNumber = static_cast<uint16_t>(strtoll(port.c_str(), nullptr, 10));
 
             m_UdpSocket.reset(new asio::ip::udp::socket(
-                m_IoService,
-                asio::ip::udp::endpoint(asio::ip::udp::v4(), portNumber)));
+                m_IoService, asio::ip::udp::endpoint(asio::ip::udp::v4(), portNumber)));
 
             std::array<char, 1> recvBuffer;
 


### PR DESCRIPTION
This PR replaces the `boost::asio` and `boost::system` dependencies with standalone `asio` and `std::system_error` and `std::error_code`. This allows us to completely remove any Boost dependency. This ideally shouldn't break the code in any way, but this would still require testing with the hardware to confirm (cc @nocoinman).

Fixes #15.